### PR TITLE
Pass container as element instead of id

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ import Heatmap from 'visual-heatmap'
 ## VisualHeatmapJs - API
 
 ### visualHeatmap()
-visualHeatmap provides a API to create context **WebGL**. API accepts containerId and config as an input. A layer will be created under the provided Div #containerId.
+visualHeatmap provides a API to create context **WebGL**. API accepts container/containerId and config as an input. A layer will be created under the provided Div #containerId.
 ```Javascript
 let instance = Heatmap('#containerId', {
         size: 30.0,
@@ -55,7 +55,7 @@ let instance = Heatmap('#containerId', {
         }]
     });
 ```
-**ContainerId** CSS Query selector which identifies container.
+**Container/ContainerId** The container div element or a string CSS Query selector which identifies the container.
 
 **Config**
 Object with config properties.

--- a/main.js
+++ b/main.js
@@ -250,7 +250,16 @@ function Heatmap (context, config = {}) {
 	}
 
 	function Chart (context, config) {
-		const res = document.querySelector(context);
+		let res;
+		if (typeof context === 'string') {
+			res = document.querySelector(context);
+		}
+		else if (context instanceof Element) {
+			res = context;
+		}
+		else {
+			throw new Error('Context must be either a string or an Element');
+		}
 		const height = res.clientHeight;
 		const width = res.clientWidth;
 		const layer = document.createElement('canvas');


### PR DESCRIPTION
@nswamy14,

Thanks for sharing this nice library!!

I would appreciate if you could review this pull request.
The first input parameter can still be a string (i.e. a CSS selector):
```
let instance = Heatmap('#containerId', { ... });
```
But from now it can also be a html element:
```
let containerElement = document.querySelector('#containerId');
let instance = Heatmap(containerElement, { ... });
```

## Background for my request
I would like to integrate your library into a VueJs application, but the problem is that I need to input a container id.  As a result, when I have multiple heatmaps, they need unique container id's (to avoid conflicts):
```
<template>
    <div id="heatmap_container_unique_id"/>
</template>
```

However VueJs can work with scoped html, by using their `ref` attribute instead of the standard `id` attribute:
```
<template>
    <div ref="heatmap_container"/>
</template>
```
So no need to have unique id's this way, i.e. all heatmap container divs can have the same `ref` value "heatmap_container, which simplifies the code.  Next I need to find the div element in the VueJs way, and pass it to your library:
```
let scopedHeatmapElement = this.$refs.heatmap_container;
let heatmapInstance = Heatmap(scopedHeatmapElement, {...});
````

Hopefully this is ok for you.

Thanks!
Bart